### PR TITLE
Dockerfile: remove run-server.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=build /lib /lib
 COPY --from=build /app /app
 
 WORKDIR /app
-CMD ["./run-server.sh"]
+ENTRYPOINT ["meowlflow"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include AUTHORS.rst
 include LICENSE
 include README.md
-include run-server.sh
 recursive-include conf *
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-PORT=${PORT:-8000}
-meowflow


### PR DESCRIPTION
Now that meowlflow is more than just a sidecar, it does not make sense
for the entrypoint to the meowlflow container to be the run-server.sh
script. Furthermore, that script does not allow passing all of the
necessary parameters to the sidecare sub-command, which means that the
script must always be bypassed and is this not really useful. This
commit removes the run-server.sh script entirely. Instead, the
entrypoint for the container is set to meowlflow, enabling more
idiomatic usage of the container, e.g.
`docker run --rm img.conny.dev/conny/meowlflow generate ...`.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>