### PR TITLE
requirements.txt: add boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ paramiko
 sentry-sdk
 click
 mlflow==1.18.0
+boto3


### PR DESCRIPTION
This commit adds boto3 to the requirements.txt file for the project. In
order to pull models from S3 repositories, and this be able to run
`meowlflow generate s3://...`, mlflow requires boto3 to be installed,
however mlflow does not declare this as a dependency, so we will declare
it explicitly in meowlflow instead.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>