### PR TITLE
Dockerfile: downgrade Python to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Change base image with python:3-aline works too
 # Base image is from Dockerfile-base
-FROM python:3-slim as build
+FROM python:3.9-slim as build
 ENV workdir=/app
 RUN mkdir -p $workdir
 WORKDIR $workdir
@@ -18,7 +18,7 @@ COPY . $workdir
 RUN pip install .
 
 # Squash layers
-FROM python:3-slim
+FROM python:3.9-slim
 
 # COPY --from=build / /   # doesn't work on kaniko
 # Waiting for: https://github.com/GoogleContainerTools/kaniko/pull/1724


### PR DESCRIPTION
This commit downgrades the version of Python used in the meowlflow
Dockerfile to 3.9 to try to improve compatibility with pypi packages.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>