### PR TITLE
meowflow/build.py: accept --workdir flag

### DIFF
--- a/meowlflow/build.py
+++ b/meowlflow/build.py
@@ -209,11 +209,11 @@ def dockerfile(model_uri, cwd, tag, mlflow_home=None, custom_steps=None):
             model_uri, output_path=model_cwd
         )
         return """
-            COPY {model_dir} /opt/ml/model
-            RUN python -c \
-            'from mlflow.models.container import _install_pyfunc_deps;\
-            _install_pyfunc_deps("/opt/ml/model", install_mlflow=False)'
-            ENV {disable_env}="true"
+COPY {model_dir} /opt/ml/model
+RUN python -c \
+'from mlflow.models.container import _install_pyfunc_deps;\
+_install_pyfunc_deps("/opt/ml/model", install_mlflow=False)'
+ENV {disable_env}="true"
             """.format(
             disable_env=mlflow_backend.DISABLE_ENV_CREATION,
             model_dir=str(posixpath.join(model_cwd, os.path.basename(model_path))),


### PR DESCRIPTION
Currently, `meowlflow generate` uses the mlflow TempDir util, which
creates a temporary directory upon entering the block and destroys the
temporary directory when leaving the block. This does not make sense for
`meowlflow generate` as the generated Dockerfile relies on the model
being available when the Docker container is actually built. If the
temporary directory is removed, then the container cannot be built. This
commit fixes this issue by adding an optional `--workdir` flag into
which the model will be downloaded. The flag defaults to the current
working directory.

Furthermore, this commit ensures that the absolute path to the model is
used in the generated Dockerfile. `meowlflow build` currently works
because the `exec` call switches to the temporary directory and uses
this as its working directory, ensuring that `COPY model_dir...` works
with relative paths. This is not possible if there is no `exec` call,
i.e. in `meowlflow generate`.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>