### PR TITLE
meowlflow/build.py: use relative path Dockerfile

### DIFF
--- a/meowlflow/build.py
+++ b/meowlflow/build.py
@@ -216,7 +216,7 @@ _install_pyfunc_deps("/opt/ml/model", install_mlflow=False)'
 ENV {disable_env}="true"
             """.format(
             disable_env=mlflow_backend.DISABLE_ENV_CREATION,
-            model_dir=str(posixpath.join(model_cwd, os.path.basename(model_path))),
+            model_dir=str(posixpath.join("model_dir", os.path.basename(model_path))),
         )
 
     mlflow_home = os.path.abspath(mlflow_home) if mlflow_home else None


### PR DESCRIPTION
Container building forces that the only files available to the build are
files that are within the current directory. All absolute paths used
during build are translated into paths relative to the current
directory.
This means that the directive:
```dockerfile
COPY /x/y .
```
will actually copy the file `$PWD/x/y` into the container.

Because of this, we have to use _only_ `model_dir` as the directory we
want to copy into the container. This will work with `meowlflow build`
and `meowlflow generate > Dockerfile && docker build .` provided that the `build`
step is executed from the directory specified with the `--workdir` flag.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>