### PR TITLE
meowlflow: try to parse mlflow response as json

### DIFF
--- a/meowlflow/sidecar.py
+++ b/meowlflow/sidecar.py
@@ -120,7 +120,7 @@ def sidecar(endpoint, upstream, schema_path, host, port):
         async with aiohttp.ClientSession() as session:
             async with session.post(upstream, data=data, headers=headers) as response:
 
-                return schema.Response.transform(await response.text())
+                return schema.Response.transform(await response.json())
 
     app.include_router(info.router)
     app.include_router(api.router)


### PR DESCRIPTION
Currently, the responses from MLFlow are being parsed as strings, which
means that the response transformers cannot deal with the response data
nicely. If we always try to parse the data as JSON, then the transformer
can work with the response more easily.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>