### PR TITLE
meowlflow/openapi.py: add openapi spec generation

### DIFF
--- a/meowlflow/cli.py
+++ b/meowlflow/cli.py
@@ -3,6 +3,7 @@ import click
 from meowlflow.sidecar import sidecar
 from meowlflow.build import build, generate
 from meowlflow.promote import promote_model
+from meowlflow.openapi import openapi
 
 
 @click.group()
@@ -17,6 +18,7 @@ cli.command("sidecar")(sidecar)
 cli.command("build")(build)
 cli.command("generate")(generate)
 cli.command("promote")(promote_model)
+cli.command("openapi")(openapi)
 
 if __name__ == "__main__":
     cli()

--- a/meowlflow/openapi.py
+++ b/meowlflow/openapi.py
@@ -1,0 +1,26 @@
+import json
+import logging
+
+import click
+from fastapi import FastAPI
+
+from meowlflow.api import api
+from meowlflow.sidecar import register_endpoint
+
+
+@click.option("--endpoint", default="/infer", type=click.Path(), show_default=True)
+@click.option(
+    "--schema-path",
+    default="/var/lib/meowlflow/schema.py",
+    type=click.Path(),
+    show_default=True,
+)
+def openapi(endpoint, schema_path):
+    log_fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    logging.basicConfig(level=logging.INFO, format=log_fmt)
+    logger = logging.getLogger(__name__)
+
+    register_endpoint(logger, api.router, endpoint, "", schema_path)
+    app = FastAPI()
+    app.include_router(api.router)
+    print(json.dumps(app.openapi()))


### PR DESCRIPTION
This commit adds a new subcommand, `meowlflow openapi`, which can be
used to generate an OpenAPI specification JSON file for a given schema.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>