### PR TITLE
api: remove unnecessary endpoints

### DIFF
--- a/meowlflow/api/info.py
+++ b/meowlflow/api/info.py
@@ -1,12 +1,10 @@
 # pylint: disable=no-name-in-module
 # pylint: disable=too-few-public-methods
-import time
 import logging
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
 import meowlflow
-from meowlflow.exception import Forbidden
 
 router = APIRouter()
 
@@ -20,22 +18,6 @@ class VersionResp(BaseModel):
 @router.get("/", tags=["info"])
 async def index():
     return await version()
-
-
-@router.get("/error", tags=["debug"])
-async def gen_error():
-    raise Forbidden("test")
-
-
-@router.get("/error_uncatched", tags=["debug"])
-async def gen_error_uncatch():
-    raise Exception()
-
-
-@router.get("/slow", tags=["debug"])
-async def slow_req():
-    time.sleep(5)
-    return {"ok": 200}
 
 
 @router.get("/version", tags=["info"], response_model=VersionResp)


### PR DESCRIPTION
This commit removes several unnecessary endpoints from the /info API of
the meowlflow sidecar.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>