### PR TITLE
Dockerfile: fix Prometheus metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ COPY --from=build /lib /lib
 COPY --from=build /app /app
 
 WORKDIR /app
+ENV PROMETHEUS_MULTIPROC_DIR=/tmp/meowlflow/prometheus
 ENTRYPOINT ["meowlflow"]


### PR DESCRIPTION
According to the Prometheus Python client documentation
(https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn),
when running an app instrumented with Prometheus metrics in
multi-process mode, the PROMETHEUS_MULTIPROC_DIR environment variable
must be set. Currently, this variable is set by Python in the
meowlflow/config.py module. However. because variables set by Python
do not necessarily propogate to child processes, the Prometheus
documentation recommends setting the variable in the shell. This commit
accomplishes the same effect by setting the variable in the container
environment.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>