### PR TITLE
meowlflow: enable OpenAPI spec customization

### DIFF
--- a/examples/document_splitter_schema.py
+++ b/examples/document_splitter_schema.py
@@ -5,6 +5,12 @@ from pydantic import BaseModel
 
 from meowlflow.api.base import BaseRequest, BaseResponse
 
+description = "A model that predicts document boundaries, where the length of the prediction array is equal to the "
+"number of pages in the input, a '0' at a given index means the page belongs to the current document, and a '1' marks "
+"the start of a new document on the given index."
+title = "Document Splitter"
+version = "0.1.0"
+
 
 class Page(BaseModel):
     text: str

--- a/meowlflow/openapi.py
+++ b/meowlflow/openapi.py
@@ -5,7 +5,7 @@ import click
 from fastapi import FastAPI
 
 from meowlflow.api import api
-from meowlflow.sidecar import register_endpoint
+from meowlflow.sidecar import register_schema
 
 
 @click.option("--endpoint", default="/infer", type=click.Path(), show_default=True)
@@ -20,7 +20,7 @@ def openapi(endpoint, schema_path):
     logging.basicConfig(level=logging.INFO, format=log_fmt)
     logger = logging.getLogger(__name__)
 
-    register_endpoint(logger, api.router, endpoint, "", schema_path)
     app = FastAPI()
+    register_schema(logger, app, api.router, endpoint, "", schema_path)
     app.include_router(api.router)
     print(json.dumps(app.openapi()))


### PR DESCRIPTION
Currently, the OpenAPI specification generated for every model exposed
by meowlflow shows the same title and version, which default to values
set by FastAPI. This commit enables setting the OpenAPI title,
description, version, and others from the schema.py file that describes
the exposed model.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>