### PR TITLE
meowlflow: enable serving model directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ For the above example, you could use the following custom schema:
 
 [replace]: # (examples/document_splitter_schema.py)
 ```python
-from typing import List
 import json
+from typing import List, Text
 
 from pydantic import BaseModel
 

--- a/examples/document_splitter_schema.py
+++ b/examples/document_splitter_schema.py
@@ -1,5 +1,5 @@
-from typing import List
 import json
+from typing import List, Text
 
 from pydantic import BaseModel
 

--- a/meowlflow/cli.py
+++ b/meowlflow/cli.py
@@ -4,6 +4,7 @@ from meowlflow.sidecar import sidecar
 from meowlflow.build import build, generate
 from meowlflow.promote import promote_model
 from meowlflow.openapi import openapi
+from meowlflow.serve import serve
 
 
 @click.group()
@@ -19,6 +20,7 @@ cli.command("build")(build)
 cli.command("generate")(generate)
 cli.command("promote")(promote_model)
 cli.command("openapi")(openapi)
+cli.command("serve")(serve)
 
 if __name__ == "__main__":
     cli()

--- a/meowlflow/openapi.py
+++ b/meowlflow/openapi.py
@@ -5,7 +5,7 @@ import click
 from fastapi import FastAPI
 
 from meowlflow.api import api
-from meowlflow.sidecar import register_schema
+from meowlflow.sidecar import register_infer_endpoint
 
 
 @click.option("--endpoint", default="/infer", type=click.Path(), show_default=True)
@@ -21,6 +21,6 @@ def openapi(endpoint, schema_path):
     logger = logging.getLogger(__name__)
 
     app = FastAPI()
-    register_schema(logger, app, api.router, endpoint, "", schema_path)
+    register_infer_endpoint(logger, app, api.router, endpoint, None, schema_path)
     app.include_router(api.router)
     print(json.dumps(app.openapi()))

--- a/meowlflow/serve.py
+++ b/meowlflow/serve.py
@@ -1,0 +1,58 @@
+import logging
+
+import click
+from fastapi import FastAPI
+import json
+from mlflow.models.container import MODEL_PATH
+from mlflow.pyfunc import load_model, scoring_server
+from mlflow.utils.file_utils import path_to_local_file_uri
+from mlflow.utils.proto_json_utils import _get_jsonable_obj
+import uvicorn
+
+from meowlflow.api import api, info
+from meowlflow.sidecar import register_infer_endpoint
+
+
+@click.option("--endpoint", default="/infer", type=click.Path(), show_default=True)
+@click.option(
+    "--schema-path",
+    default="/var/lib/meowlflow/schema.py",
+    type=click.Path(),
+    show_default=True,
+)
+@click.option("--host", default="0.0.0.0", type=str, show_default=True)
+@click.option("--port", default=8000, type=int, show_default=True)
+def serve(endpoint, schema_path, host, port):
+    log_fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    logging.basicConfig(level=logging.INFO, format=log_fmt)
+    logger = logging.getLogger(__name__)
+
+    logger.info(f"Setting inference endpoint to {endpoint}")
+    logger.info(f"Using host {host}")
+    logger.info(f"Using port {port}")
+
+    model = load_model(path_to_local_file_uri(MODEL_PATH))
+    model_schema = model.metadata.get_input_schema()
+
+    app = FastAPI()
+    register_infer_endpoint(
+        logger, app, api.router, endpoint, get_infer(model, model_schema), schema_path
+    )
+    app.include_router(info.router)
+    app.include_router(api.router)
+    uvicorn.run(app, host=host, port=port, log_level="debug")
+
+
+def get_infer(model, schema):
+    async def infer(data):
+        data = scoring_server.parse_json_input(
+            json_input=data,
+            orient="records",
+            schema=schema,
+        )
+        prediction = model.predict(data)
+        return json.loads(
+            json.dumps(_get_jsonable_obj(prediction, pandas_orient="records"))
+        )
+
+    return infer


### PR DESCRIPTION
This commit enables a new operational mode for meowlflow where it serves
the model directly, rather than needing to proxy HTTP requests to an
MLFlow HTTP server. This allows for simplified deployment configuration
and can potentially provide a speed up as serializations to and from
JSON can be avoided. Note: this current implementation requires an extra
JSON serialization+deserialization step after obtaining predictions, as
it is currently expected that the Response.transform method operates on
basic/non-pandas/non-numpy types. Perhaps this can be avoided by
converting prediction results into simpler dicts/lists before passing to
Response.transform? Otherwise this could be avoided by standardizing on
the convention that the transform methods always accept andreturn JSON.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>