### PR TITLE
meowlflow: fix OpenAPI operation ID

### DIFF
--- a/meowlflow/sidecar.py
+++ b/meowlflow/sidecar.py
@@ -120,7 +120,7 @@ def get_infer(upstream):
     return infer
 
 
-def register_infer_endpoint(logger, app, router, endpoint, infer, schema_path):
+def register_infer_endpoint(logger, app, router, endpoint, _infer, schema_path):
     logger.info(f"Loading schema module from {schema_path}")
     schema = _load_module(schema_path, "schema")
 
@@ -144,7 +144,7 @@ def register_infer_endpoint(logger, app, router, endpoint, infer, schema_path):
     endpoint = _to_endpoint_path(endpoint)
 
     @router.post(endpoint, response_model=schema.Response)
-    async def _infer(request: schema.Request):
+    async def infer(request: schema.Request):
         data = request.transform()
-        response = await infer(data)
+        response = await _infer(data)
         return schema.Response.transform(response)


### PR DESCRIPTION
Since the method that is decorated with the FastAPI router was renamed
to `_infer`, the auto-generated OpenAPI summary and operation ID were
renamed to ` Infer` and `_infer_api_v1_infer_post` respectively, from
the nicer `Infer` and `infer_api_v1_infer_post`. This commit changes the
method name back to `infer` so that the generated OpenAPI specification
includes more aesthetic values.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>