### PR TITLE
meowlflow/serve: reuse app to inherit config

### DIFF
--- a/meowlflow/serve.py
+++ b/meowlflow/serve.py
@@ -1,7 +1,6 @@
 import logging
 
 import click
-from fastapi import FastAPI
 import json
 from mlflow.models.container import MODEL_PATH
 from mlflow.pyfunc import load_model, scoring_server
@@ -10,7 +9,7 @@ from mlflow.utils.proto_json_utils import _get_jsonable_obj
 import uvicorn
 
 from meowlflow.api import api, info
-from meowlflow.sidecar import register_infer_endpoint
+from meowlflow.sidecar import app, register_infer_endpoint
 
 
 @click.option("--endpoint", default="/infer", type=click.Path(), show_default=True)
@@ -40,7 +39,6 @@ def serve(endpoint, schema_path, model_path, host, port):
     model = load_model(path_to_local_file_uri(model_path))
     model_schema = model.metadata.get_input_schema()
 
-    app = FastAPI()
     register_infer_endpoint(
         logger, app, api.router, endpoint, get_infer(model, model_schema), schema_path
     )


### PR DESCRIPTION
Currently, the serve command instantiates its own FastAPI app, without
any of the configuration used in the sidecar.py module. This is a
problem because we miss out on the middleware and metrcs. This commit
changes the serve.py module so that it reuses the existing app.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>