### PR TITLE
Makefile: clarify README generation message

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,11 @@ diff:
   script:
     - make README.md -B
     - |
-        [ "$(git status --porcelain 2>/dev/null | wc -l )" -eq 0 ]
+        DIFF="$(git status --porcelain 2>/dev/null )"
+        if [ "$(echo -n "$DIFF" | wc -l)" -ne 0 ]; then
+          printf 'README.md is out of date!\nDiff:\n%s\nRun:\n\tmake README.md\n' "$DIFF"
+          exit 1
+        fi
 
 lint:
   tags:

--- a/Makefile
+++ b/Makefile
@@ -137,4 +137,4 @@ rename:
 SRC := $(shell find . -type f -name '*.py')
 
 README.md: $(SRC)
-	perl -i -n0e 'while(/(.*?)^(\[replace\]:\s*#\s*\(([^\n]*)\)\n```[^\n]*\n).*?^(```)$$(.*?)/smg){print "$$1$$2"; open (FILE, "<", "$$3") or die "could not open the log file $$3\n";print <FILE>;close (FILE); print "$$4\n$$5"}' $@
+	@perl -i -n0e 'while(/(.*?)^(\[replace\]:\s*#\s*\(([^\n]*)\)\n```[^\n]*\n).*?^(```)$$(.*?)/smg){print "$$1$$2"; open (FILE, "<", "$$3") or die "could not open file: $$3\n";print <FILE>;close (FILE); print "$$4\n$$5"}' $@


### PR DESCRIPTION
This commit is intended to clarify the messages printed when running
`make README.md`. This change makes it so that nothing is printed to the
screen if everything works successfully, and a message is only printed
on failure.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>