### PR TITLE
Expose port 8000 in meowlflow generated docker image

### DIFF
--- a/meowlflow/build.py
+++ b/meowlflow/build.py
@@ -67,7 +67,7 @@ ENV PATH="/miniconda/bin:$PATH"
 ENV GUNICORN_CMD_ARGS="--bind 0.0.0.0:8000 --timeout 60 -k gevent"
 ENV DISABLE_NGINX=true
 
-EXPOSE PORT 8000
+EXPOSE 8000
 
 WORKDIR /opt/mlflow
 ENTRYPOINT ["python", "-c", "from mlflow.models import container as C; C._serve()"]


### PR DESCRIPTION
To test the docker image in CI, we make use of gitlab services
https://github.com/mietright/rental-multiclass/blob/af64f6d52da0db009e18f4dd5377629e7cd310db/.gitlab-ci/rental-multiclass-deploy.yml#L40

However, Gitlab services do not allow for exposing ports, so this is a workaround
See: https://stackoverflow.com/questions/45496356/how-are-gitlab-ci-service-ports-exposed