### PR TITLE
CI: don't build images for armv7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/arm64, linux/arm, linux/amd64
+        platforms: linux/arm64, linux/amd64
         tags: ghcr.io/connylabs/meowlflow:latest, ghcr.io/connylabs/meowlflow:${{ steps.sha.outputs.sha }}
     - name: Determine digest
       run: echo ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
Prebuilt wheels often don't exist for ARMv7, and building these, e.g.
for scipy, under emulation in CI takes prohibitively long, if it even
succeeds so this commit removes ARMv7 as a build target for CI.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
