### PR TITLE
e2e: add scenario for generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install dependencies
       run: poetry install
     - name: mypy
-      run: poetry run mypy examples meowlflow
+      run: poetry run mypy e2e examples meowlflow
 
   e2e:
     runs-on: ubuntu-latest

--- a/meowlflow/openapi.py
+++ b/meowlflow/openapi.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 import click
@@ -20,10 +21,10 @@ from meowlflow.sidecar import (
 @click.option(
     "--schema-path",
     default="/var/lib/meowlflow/schema.py",
-    type=click.Path(),
+    type=click.Path(exists=True, dir_okay=False),
     show_default=True,
 )
-def openapi(endpoint: str, schema_path: str) -> None:
+def openapi(endpoint: str, schema_path: Path) -> None:
     app = FastAPI()
 
     async def infer(_: Any) -> Any:

--- a/meowlflow/serve.py
+++ b/meowlflow/serve.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
@@ -27,19 +28,19 @@ from meowlflow.sidecar import (
 @click.option(
     "--endpoint",
     default="/infer",
-    type=click.Path(),
+    type=str,
     show_default=True,
 )
 @click.option(
     "--schema-path",
     default="/var/lib/meowlflow/schema.py",
-    type=click.Path(),
+    type=click.Path(exists=True, dir_okay=False),
     show_default=True,
 )
 @click.option(
     "--model-path",
     default=MODEL_PATH,
-    type=click.Path(),
+    type=str,
     show_default=True,
 )
 @click.option(
@@ -55,7 +56,7 @@ from meowlflow.sidecar import (
     show_default=True,
 )
 def serve(
-    endpoint: str, schema_path: str, model_path: str, host: str, port: int
+    endpoint: str, schema_path: Path, model_path: str, host: str, port: int
 ) -> None:
     log_fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     logging.basicConfig(level=logging.INFO, format=log_fmt)

--- a/meowlflow/sidecar.py
+++ b/meowlflow/sidecar.py
@@ -23,7 +23,7 @@ from meowlflow.api.middlewares.errors import (
 )
 
 
-def _load_module(module_path: str, module_name: str) -> types.ModuleType:
+def _load_module(module_path: Path, module_name: str) -> types.ModuleType:
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if TYPE_CHECKING:
         assert spec is not None
@@ -65,7 +65,7 @@ app.middleware("http")(catch_exceptions_middleware)
 @click.option(
     "--endpoint",
     default="/infer",
-    type=click.Path(),
+    type=str,
     show_default=True,
 )
 @click.option(
@@ -77,7 +77,7 @@ app.middleware("http")(catch_exceptions_middleware)
 @click.option(
     "--schema-path",
     default="/var/lib/meowlflow/schema.py",
-    type=click.Path(),
+    type=click.Path(exists=True, dir_okay=False),
     show_default=True,
 )
 @click.option(
@@ -93,7 +93,7 @@ app.middleware("http")(catch_exceptions_middleware)
     show_default=True,
 )
 def sidecar(
-    endpoint: str, upstream: str, schema_path: str, host: str, port: int
+    endpoint: str, upstream: str, schema_path: Path, host: str, port: int
 ) -> None:
     log_fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     logging.basicConfig(level=logging.INFO, format=log_fmt)
@@ -147,7 +147,7 @@ def register_infer_endpoint(
     router: routing.APIRouter,
     endpoint: str,
     _infer: Infer,
-    schema_path: str,
+    schema_path: Path,
 ) -> None:
     if logger is not None:
         logger.info(f"Loading schema module from {schema_path}")


### PR DESCRIPTION
This commit enhances the e2e test suite with a new test for the
`meowlflow generate` command. In writing the tests I realized that it
would be an easy win to add a new option to the `build` and `generate`
commands to optionally copy the model schema into the container.
Currently, whenever we run a meowlflow container we have to mount a
volume with the schema, which works totally fine, but is potentially an
additional source of complexity. When the `--schema-path` option is
provided, the Dockerfile is modified to include extra directives to copy
the schema to the cannonical meowlflow schema path, i.e.
`/var/lib/meowlflow/schema.py`. This allows baking a versioned schema
into a container alongside a versioned model, which is nice for
reproducibility. The option of mounting the schema into the container at
run-time is of course still available.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
