### PR TITLE
meowlflow: remove import for side effects

### DIFF
--- a/meowlflow/__init__.py
+++ b/meowlflow/__init__.py
@@ -3,11 +3,6 @@ import os
 import subprocess
 from pathlib import Path
 
-# Import boto3 so that it is added to our dependencies
-# and tracked by pipreqs as it's a dependency when using mlflow
-# with an S3 backend.
-import boto3  # noqa: F401
-
 
 def _parse_version() -> str:
     version_file = list(Path(__file__).resolve().parents[1].glob("VERSION"))


### PR DESCRIPTION
Previously, meowlflow used pipreqs to generate the list of used
packages in a requirements.txt without collecting everything from the
environment. In order to do this, pipreqs analyzes all of the import
statements in the package. Because the project depended on boto3 but it
was not explicitly used, an import needed to be added for the side
effect of indicating to pipreqs that this package was indeed a
dependency. However, now that this package uses Poetry for its
dependency management we can explicitly add boto3 to the dependency list
and remove the unused import.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
