### PR TITLE
CI: add tooling to distribute project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-.git
-!.git/HEAD
 .gitignore
 ROADMAP.md
 .DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install poetry
-      run: pipx install poetry
+      run: pipx install poetry && poetry self add poetry-dynamic-versioning
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -91,7 +91,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install poetry
-      run: pipx install poetry
+      run: pipx install poetry && poetry self add poetry-dynamic-versioning
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -129,6 +129,33 @@ jobs:
     - name: Check dependencies
       run: poetry lock --check
 
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install poetry
+      run: pipx install poetry && poetry self add poetry-dynamic-versioning
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        cache: poetry
+    - name: Tag version
+      run: |
+        if ! git describe --tags --exact-match 2>/dev/null; then
+          # If this commit doesn't correspond to a tag, then tag with something we won't use.
+          git tag 0.0.0-rc$GITHUB_RUN_ID
+        fi
+    - name: Build dist
+      run: poetry build
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
+        verbose: true
+
   push:
     if: github.event_name != 'pull_request'
     needs:
@@ -139,6 +166,7 @@ jobs:
     - e2e
     - container
     - dependencies
+    - dist
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -165,3 +193,30 @@ jobs:
         tags: ghcr.io/connylabs/meowlflow:latest, ghcr.io/connylabs/meowlflow:${{ steps.sha.outputs.sha }}
     - name: Determine digest
       run: echo ${{ steps.push.outputs.digest }}
+
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs:
+    - docs
+    - lint
+    - smoke
+    - types
+    - e2e
+    - container
+    - dependencies
+    - dist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install poetry
+      run: pipx install poetry && poetry self add poetry-dynamic-versioning
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Build dist
+      run: poetry build
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM python:3.9-slim as build
-ENV workdir=/app
+ENV workdir=/src
 RUN mkdir -p $workdir
 WORKDIR $workdir
 RUN apt-get update
 RUN apt-get install -y openssl ca-certificates
 RUN apt-get install -y libffi-dev build-essential libssl-dev git rustc cargo
 RUN pip install pip -U
-COPY . $workdir
+COPY . .
 RUN pip install poetry
+RUN poetry self add poetry-dynamic-versioning
 RUN pip install .
 RUN apt-get remove --purge -y libffi-dev build-essential libssl-dev git rustc cargo
 RUN rm -rf /root/.cargo
@@ -20,9 +21,7 @@ COPY --from=build /usr /usr
 COPY --from=build /home /home
 COPY --from=build /opt /opt
 COPY --from=build /lib /lib
-COPY --from=build /app /app
 
-WORKDIR /app
 ENV PROMETHEUS_MULTIPROC_DIR=/tmp/meowlflow/prometheus
 RUN mkdir -p $PROMETHEUS_MULTIPROC_DIR
 ENTRYPOINT ["meowlflow"]

--- a/e2e/meowlflow.sh
+++ b/e2e/meowlflow.sh
@@ -63,3 +63,7 @@ test_generate() {
     assert "poetry run meowlflow generate mlflow-artifacts:/0/$RUN_ID/artifacts/model --workdir=$(mktemp -d) --custom-steps 'RUN echo i love meowlflow' | grep -q 'RUN echo i love meowlflow'" "should create Dockerfile custom steps"
     assert "poetry run meowlflow generate mlflow-artifacts:/0/$RUN_ID/artifacts/model --workdir=$(mktemp -d) --schema-path mlflow_example_schema.py | grep -q 'COPY mlflow_example_schema.py /var/lib/meowlflow/schema.py'" "should create Dockerfile with step to copy model schema"
 }
+
+test_version() {
+    assert "poetry run meowlflow --version | cut -d' ' -f3 | grep $(git describe --tags --exact-match 2>/dev/null || git describe --always --abbrev=7 | tail -c8)" "package version should match tag or abbreviated Git commit"
+}

--- a/meowlflow/__init__.py
+++ b/meowlflow/__init__.py
@@ -1,36 +1,10 @@
 # -*- coding: utf-8 -*-
-import os
-import subprocess
-from pathlib import Path
+from importlib.metadata import version, PackageNotFoundError
 
 
-def _parse_version() -> str:
-    version_file = list(Path(__file__).resolve().parents[1].glob("VERSION"))
-    if version_file:
-        return version_file[0].read_text().strip()
-    return "0.0.1"
-
-
-__version__ = _parse_version()
-
-
-def _get_git_sha() -> str:
-    if os.path.exists("GIT_HEAD"):
-        with open("GIT_HEAD", "r", encoding="utf-8") as openf:
-            return openf.read()
-    else:
-        try:
-            return (
-                subprocess.check_output(["git", "rev-parse", "HEAD"])
-                .strip()[0:8]
-                .decode()
-            )
-        except (
-            OSError,
-            subprocess.CalledProcessError,
-        ):
-            pass
-    return "unknown"
-
-
-__gitsha__ = _get_git_sha()
+__version__ = "0.0.0"
+try:
+    __version__ = version("meowlflow")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/meowlflow/cli.py
+++ b/meowlflow/cli.py
@@ -1,5 +1,6 @@
 import click
 
+import meowlflow
 from meowlflow.sidecar import sidecar
 from meowlflow.build import build, generate
 from meowlflow.promote import promote_model
@@ -8,6 +9,7 @@ from meowlflow.serve import serve
 
 
 @click.group()
+@click.version_option(version=meowlflow.__version__)
 def cli() -> None:
     """
     main meowlflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.poetry]
-name = "MeowlFlow"
-version = "0.1.0"
+name = "meowlflow"
+version = "0.0.0"
 description = "serving ML models like the cat's meow"
+license = "Apache-2.0"
 authors = ["Conny Tech <tech@conny.legal>"]
+homepage = "https://github.com/connylabs/meowlflow"
+readme = "README.md"
+keywords = ["mlflow", "fastapi", "openapi"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -30,8 +34,15 @@ pandas = "^1.4.3"
 meowlflow = "meowlflow.cli:cli"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"
+# Make the leading 'v' optional.
+pattern  = "^(?P<base>\\d+\\.\\d+\\.\\d+)(-?((?P<stage>[a-zA-Z]+)\\.?(?P<revision>\\d+)?))?"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
This commit adds tooling to CI to automatically build wheels for the
project and publish them to pypi. This is done using the
`pypa/gh-action-pypi-publish` GitHub action. Furthermore, versioning for
the project is simplified to _always_ use Git tags as the source of
truth. Previsouly, the version in pyproject.toml and under
meowlflow/__init__.py had to be manually kept up to date; this is now
done automatically using the `poetry-dynamic-versioning` poetry plugin.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
