### PR TITLE
MANIFEST.in: remove thanks to Poetry

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,0 @@
-include AUTHORS.rst
-include LICENSE
-include README.md
-recursive-include tests *
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
-
-recursive-include docs *.rst Makefile make.bat


### PR DESCRIPTION
Since we use poetry for building our package, we no longer need the
MANIFEST.in file at all. This commit removes the file in favor of
poetry-specific include/exclude sections in the pyproject.toml file.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
