### PR TITLE
fix bug in parsing experiment_id

### DIFF
--- a/meowlflow/promote.py
+++ b/meowlflow/promote.py
@@ -31,7 +31,7 @@ def get_run_by_sha(commit: str, experiment_id: int) -> Run:
     mlflow Run instance
     """
     run = mlflow.search_runs(
-        list(str(experiment_id)),
+        [int(experiment_id)],
         filter_string=f'tags.mlflow.source.git.commit = "{commit}"',
         max_results=1,
         output_format="list",


### PR DESCRIPTION
currently we have a bug since for integer `experiment_id=10`:
`list(str(experiment_id))` will yield `['1','0']`