### PR TITLE
meowlflow/promote.py: automatically create models

### DIFF
--- a/e2e/meowlflow.sh
+++ b/e2e/meowlflow.sh
@@ -44,6 +44,7 @@ test_openapi() {
 
 test_promote() {
     export MLFLOW_TRACKING_URI=http://localhost:5000
+    assert_fail "poetry run meowlflow promote 0651d1c962aa35e4dd02608c51a7b0efc2412407 0 e2e --do-not-create-model --metric rmse" "promotion should fail if the model does not exist and automatic model creation is disabled"
     # Create MLflow experiment.
     assert "poetry run mlflow run https://github.com/mlflow/mlflow-example.git -P alpha=5.0 --env-manager=local" "should create experiment run in MLflow"
     # Create a new MLflow model using the HTTP API, since there is no command for it.
@@ -51,6 +52,7 @@ test_promote() {
     assert "poetry run meowlflow promote 0651d1c962aa35e4dd02608c51a7b0efc2412407 0 e2e --exit-code 1 --metric rmse" "model promotion should succeed when no run has been registered"
     assert_fail "poetry run meowlflow promote 0651d1c962aa35e4dd02608c51a7b0efc2412407 0 e2e --exit-code 1 --metric rmse" "model promotion should fail if the same run has already been registered"
     assert "poetry run meowlflow promote 0651d1c962aa35e4dd02608c51a7b0efc2412407 0 e2e --exit-code 1 --metric rmse --force" "model promotion should succeed when using force"
+    assert "poetry run meowlflow promote 0651d1c962aa35e4dd02608c51a7b0efc2412407 0 e2e2 --exit-code 1 --metric rmse" "model promotion should succeed even when the model does not exist yet"
 }
 
 test_generate() {

--- a/meowlflow/promote.py
+++ b/meowlflow/promote.py
@@ -39,14 +39,16 @@ def get_run_by_sha(commit: str, experiment_id: int) -> Run:
     return run
 
 
-def get_run_by_stage(stage: str, model_name: str) -> Optional[Run]:
+def get_run_by_stage(stage: str, model_name: str, auto_create: bool) -> Optional[Run]:
     """get the run for the model at a given stage
 
     Parameters
     ----------
     model_name : str, name to register for the model
-    stage : str, default: "staging"
+    stage : str
         name of stage to which this model should be considered for promotion
+    auto_create : bool
+        should a model be automatically created if no matching model is found?
 
     Returns
     -------
@@ -57,7 +59,10 @@ def get_run_by_stage(stage: str, model_name: str) -> Optional[Run]:
         max_results=1,
     )
     if not rms:
-        raise ValueError(f"Found no registered model with name: {model_name}")
+        if not auto_create:
+            raise ValueError(f"Found no registered model with name: {model_name}")
+        _get_registry().create_registered_model(model_name)
+        return None
 
     for version in rms[0].latest_versions:
         if version.current_stage.lower() == stage.lower():
@@ -104,6 +109,12 @@ def register_model(run: Run, model_name: str) -> ModelVersion:
 )
 @click.option("--force", is_flag=True)
 @click.option(
+    "--do-not-create-model",
+    is_flag=True,
+    help="do not try to automatically create a model with the given name if no \
+matching model is found",
+)
+@click.option(
     "--exit-code",
     default=0,
     type=int,
@@ -114,18 +125,20 @@ def promote_model(
     commit: str,
     experiment_id: int,
     model_name: str,
-    metric: str = "test_f1",
-    direction: str = "maximize",
-    stage: str = "staging",
-    force: bool = False,
-    exit_code: int = 0,
+    metric: str,
+    direction: str,
+    stage: str,
+    force: bool,
+    do_not_create_model: bool,
+    exit_code: int,
 ) -> ModelVersion:
-    """attempt promotion of model with a given commit and experiment-id
+    """Attempt promotion of a specified model with a given commit and experiment-id.
 
-    in order to promote
+    If the model's performance surpasses that of the currently staged model,
+    the model will be registered and then promoted.
 
-    if model performance surpasses current staged model,
-        model will be registered and then promoted
+    Note: by default, if no model exists with the given name, then a new model will
+    be created; this behavior can be disabled using the --do-not-create-model flag.
 
     Parameters
     ----------
@@ -150,7 +163,7 @@ def promote_model(
     mlflow RegisteredModelVersion instance
     """
     run = get_run_by_sha(commit, experiment_id)
-    staged_run = get_run_by_stage(stage, model_name)
+    staged_run = get_run_by_stage(stage, model_name, not do_not_create_model)
 
     if staged_run is not None:
         promote = force or _COMPARE[direction](


### PR DESCRIPTION
This commit enhances meowlflow so that models are automatically created
during promotion if they do not yet exist. This matches the expected
user experience of allowing promotion when a model exists but no version
has been staged yet, which essentially asserts that the current run must
be better than nothing.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
