### PR TITLE
API: fix prometheus metrics in API

### DIFF
--- a/meowlflow/build.py
+++ b/meowlflow/build.py
@@ -72,6 +72,8 @@ ENV DISABLE_NGINX=true
 EXPOSE 8000
 
 WORKDIR /opt/mlflow
+ENV PROMETHEUS_MULTIPROC_DIR=/tmp/meowlflow/prometheus
+RUN mkdir -p $PROMETHEUS_MULTIPROC_DIR
 ENTRYPOINT ["python", "-c", "from mlflow.models import container as C; C._serve()"]
 """  # noqa: E501
 


### PR DESCRIPTION
Prometheus metrics are not working right now because the multiprocessing
directory is not specified, so even though the /metrics HTTP path gives
a 200, no metrics are shown, which results in no metrics being scraped
for any services built on meowlflow. This commit fixes this issue.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
