### PR TITLE
CI: remove publishing to test.pypi.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,13 +148,6 @@ jobs:
         fi
     - name: Build dist
       run: poetry build
-    - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
-        verbose: true
 
   push:
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
CI fails when trying to push to test.pypi.org on PRs because the
credentials don't aren't loaded on PRs. This removes the step because it
doesn't exactly add extra confidence in our workflows but adds a lot of
annoyance when the tests fail.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
